### PR TITLE
Fix bugs in forecast auxiliary info.

### DIFF
--- a/starchasers/controllers/api/proxy_handler.py
+++ b/starchasers/controllers/api/proxy_handler.py
@@ -24,12 +24,11 @@ def proxy_request(endpoint):
         "Token": API_TOKEN
     }
 
-    print(f"{DATASERVER_URL}/{endpoint}/?{query_string}")
+    # NOTE: only for debugging purposes.
+    # print(f"{DATASERVER_URL}/{endpoint}/?{query_string}")
+    url = f"{DATASERVER_URL}/{endpoint}/?{query_string}"
 
-    response = requests.get(
-        f"{DATASERVER_URL}/{endpoint}/?{query_string}", headers=headers,
-        timeout=10
-    )
+    response = requests.get(url, headers=headers, timeout=10)
 
     if response.status_code == 200:
         data = response.json()

--- a/starchasers/logger.py
+++ b/starchasers/logger.py
@@ -1,3 +1,4 @@
+"""Set up a logger for starchasers."""
 import logging
 from logging.handlers import TimedRotatingFileHandler
 

--- a/starchasers/static/js/details/historyChart.jsx
+++ b/starchasers/static/js/details/historyChart.jsx
@@ -148,7 +148,8 @@ class HistoryTransparencyChart extends React.Component {
                       let label = "";
                       const transparency =
                         translation[fetchedData.transparency[numericalMonth]];
-                      const cloud = fetchedData.cloud[numericalMonth].toFixed(2);
+                      const cloud =
+                        fetchedData.cloud[numericalMonth].toFixed(2);
                       const humidity =
                         fetchedData.humidity[numericalMonth].toFixed(2);
                       const aerosol =

--- a/starchasers/static/js/details/milkyWayActivity.jsx
+++ b/starchasers/static/js/details/milkyWayActivity.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import React from "react";
 import PropTypes from "prop-types";
 import { simplifyMonth } from "./utils";
@@ -29,8 +30,8 @@ class MilkyWay extends React.Component {
         <h5 className="milky-way-activity-title">
           Milky Way Center Rise and Set
         </h5>
-        {milkyWayData.activity.map((object) => (
-          <p key={`milkyway-activity-${object.rise}-${object.set}`}>
+        {milkyWayData.activity.map((object, index) => (
+          <p key={`milkyway-activity-${object.rise}-${object.set} ${index}`}>
             {simplifyMonth(object.rise, inputFormat, outputFormat)} —{" "}
             {simplifyMonth(object.set, inputFormat, outputFormat)} <br /> (
             {simplifyMonth(object.transit, inputFormat, outputFormat)})

--- a/starchasers/static/js/details/nightInfo.jsx
+++ b/starchasers/static/js/details/nightInfo.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+/* eslint-disable react/no-array-index-key */
 import React from "react";
 import PropTypes from "prop-types";
 import { simplifyMonth } from "./utils";
@@ -26,8 +27,8 @@ class DarkHours extends React.Component {
     return (
       <div className="col auxiliary dark-hours">
         <h5 className="dark-hours-title">Dark Hours</h5>
-        {darkHours.map((object) => (
-          <p key={`dark-hour-${object.set}-${object.rise}`}>
+        {darkHours.map((object, index) => (
+          <p key={`dark-hour-${object.set}-${object.rise} ${index}`}>
             {simplifyMonth(object.set, inputFormat, outputFormat)} —{" "}
             {simplifyMonth(object.rise, inputFormat, outputFormat)}
           </p>
@@ -54,8 +55,8 @@ class MoonPhase extends React.Component {
     return (
       <div className="col auxiliary moon-phase">
         <h5 className="moon-title">Moon Set and Rise</h5>
-        {moonPhase.map((object) => (
-          <p key={`moon-phase-${object.set}-${object.rise}`}>
+        {moonPhase.map((object, index) => (
+          <p key={`moon-phase-${object.set}-${object.rise} ${index}`}>
             {simplifyMonth(object.set, inputFormat, outputFormat)} —{" "}
             {simplifyMonth(object.rise, inputFormat, outputFormat)}
           </p>
@@ -100,12 +101,16 @@ class Score extends React.Component {
         <br />
         <h3 className="score">{score}</h3>
 
-        <p className="score-annotations-title">
-          {scoreTable[score].split(":")[0]}
-        </p>
-        <p className="score-annotations-content">
-          {scoreTable[score].split(":")[1]}
-        </p>
+        {score !== "No available score" && (
+          <>
+            <p className="score-annotations-title">
+              {scoreTable[score].split(":")[0]}
+            </p>
+            <p className="score-annotations-content">
+              {scoreTable[score].split(":")[1]}
+            </p>
+          </>
+        )}
       </div>
     );
   }

--- a/starchasers/static/js/details/trend.jsx
+++ b/starchasers/static/js/details/trend.jsx
@@ -13,7 +13,6 @@ class Trend extends React.Component {
     const endpoint = "/api/historical-transparency/";
     const parameters = window.location.search;
     const url = `${endpoint}${parameters}`;
-    console.log(url);
     fetch(url, { credentials: "same-origin" })
       .then((response) => {
         if (!response.ok) throw Error(response.statusText);


### PR DESCRIPTION
1. Originally when there is no available score, it still tries to parse the literals "No available score" and find an interpretation for it, causing the page to fail. Now it first checks if the score is available and only proceeds if the answer is yes.

2. Avoid console error that occurs when there are duplicate items, e.g. dark hours, moon activity, and Milky Way activity. Duplicate items themselves are not solved at this point due to the complex nature of python `ephem` library.

3. Fixed style.